### PR TITLE
add set_cfg_param for single value updates

### DIFF
--- a/src/faster_live_portrait/pipelines/faster_live_portrait_pipeline.py
+++ b/src/faster_live_portrait/pipelines/faster_live_portrait_pipeline.py
@@ -56,6 +56,21 @@ class FasterLivePortraitPipeline:
                 logging.info("add {}:{} to infer cfg".format(key, args_user[key]))
                 self.cfg.infer_params[key] = args_user[key]
         return update_ret
+    
+    def set_cfg_param(self, key, value):
+        container = None
+        if key in self.cfg.infer_params:
+            container = self.cfg.infer_params
+        elif key in self.cfg.crop_params:
+            container = self.cfg.crop_params
+        else:
+            container = self.cfg.infer_params  # fallback
+
+        if container.get(key) != value:
+            print(f"update cfg {key} from {container.get(key)} to {value}")
+            container[key] = value
+            return True
+        return False
 
     def clean_models(self, **kwargs):
         """


### PR DESCRIPTION
Updating via update_cfg produces excessive logging and appears to lose ~3fps.

This method allows us to inexpensively check for changes in the ComfyUI-FasterLivePortrait node and only apply changes to the intended parameter.